### PR TITLE
Add TLS module

### DIFF
--- a/modules.go
+++ b/modules.go
@@ -7,4 +7,5 @@ import (
         _ "github.com/gliderlabs/logspout/routesapi"
         _ "github.com/gliderlabs/logspout/transports/tcp"
         _ "github.com/gliderlabs/logspout/transports/udp"
+        _ "github.com/gliderlabs/logspout/transports/tls"
 )


### PR DESCRIPTION
Just merging default TLS module from `logspout` repo https://github.com/gliderlabs/logspout/blob/master/modules.go
