### PR TITLE
Roll back to pinned logspout version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gliderlabs/logspout:master
+FROM gliderlabs/logspout:v3.2.8
+
 ENTRYPOINT ["/ecs-entry.sh"]
 
 COPY ecs-entry.sh /ecs-entry.sh


### PR DESCRIPTION
This change pins the log spout version to an older version 3.2.8 to combat the issue seen in the last update where the logfile name was being truncated to roughly 33 characters for some reason.  We can possibly roll forward again if they fix this issue with another update.

Merging to master helps us not change all our clusters to use the pinned version and the functionality of our signiant-logspout container remains.